### PR TITLE
Ensure FactInt is loaded when the test suite runs

### DIFF
--- a/tst/testall.g
+++ b/tst/testall.g
@@ -6,6 +6,7 @@
 ##  metadata in PackageInfo.g.
 ##
 LoadPackage( "StandardFF" );
+LoadPackage( "FactInt" );
 
 TestDirectory(DirectoriesPackageLibrary( "StandardFF", "tst" ),
   rec(exitGAP := true));


### PR DESCRIPTION
FactInt is only a suggested dependency of StandardFF, so it can
happen that it is not loaded here. But then some of the tests fail.
So just make sure it is always loaded here.
