### PR TITLE
Turn "AsVector" into an attribute

### DIFF
--- a/lib/StandardFF.gd
+++ b/lib/StandardFF.gd
@@ -28,7 +28,7 @@ DeclareAttribute("TowerBasis", IsStandardFiniteField);
 DeclareOperation("SteinitzNumber", [IsStandardFiniteField, IsRingElement]);
 DeclareOperation("ElementSteinitzNumber", [IsStandardFiniteField, IsInt]);
 
-DeclareOperation("AsVector", [IsStandardFiniteFieldElement]);
+DeclareAttribute("AsVector", IsStandardFiniteFieldElement);
 DeclareAttribute("GeneratorMonomials", IsStandardFiniteField);
 DeclareAttribute("TowerBasisMonomials", IsStandardFiniteField);
 DeclareAttribute("AsPolynomial", IsStandardFiniteFieldElement);


### PR DESCRIPTION
The name suggests that it might be an attribute and other packages (QPA2, https://github.com/sunnyquiver/QPA2) use it as such, which causes issues when loading them together with StandardFF.