### PR TITLE
change one `PrimitiveElement` call to a call of `PrimitiveRoot`?

### DIFF
--- a/lib/Util.gi
+++ b/lib/Util.gi
@@ -760,7 +760,7 @@ InstallGlobalFunction(ZeroesConway, function(K)
   f := GF(p^n);
   # we precompute the list of x^(p^i) mod Conway polynomial,
   # i < n (using GAPs arithemetic in GF(p^n) and computing Z(p,n)^(p^i)).
-  x := PrimitiveElement(f);
+  x := PrimitiveRoot(f);
   l := [x];
   for i in [1..n-1] do
     Add(l, l[i]^p);


### PR DESCRIPTION
Most of the `PrimitiveElement` calls in the package take a field that is created as an algebraic extension.
The call in `lib/Util.gi` refers to a field that is constructed with `GF`, and is used to construct elements `Z(p,n)^(p^i)`.
Therefore I think that  in this situation, one should call `PrimitiveRoot` instead.

(The fields constructed with `GF` store the same element as `PrimitiveElement` and `PrimitiveRoot`, thus there is probably no problem in practice, but I think one cannot rely on this feature.)